### PR TITLE
Use only OSV-Scanner for scan workflows

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -14,28 +14,33 @@ permissions:
 
 jobs:
   go:
-    name: "go (osv-scanner)"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.ref }}
       - name: Set up Go
+        id: setup-go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: stable
           check-latest: true
+      - name: Install OSV-Scanner
+        run: |
+          go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest
+      - name: Create OSV-Scanner config
+        run: |
+          echo "GoVersionOverride = '${{ steps.setup-go.outputs.go-version }}'" > osv-scanner.toml
       - name: Scan
-        run: make scan-go-osv-scanner
+        run: |
+          osv-scanner scan \
+            --config osv-scanner.toml \
+            --lockfile go.mod \
+            --format markdown >> ${GITHUB_STEP_SUMMARY} \
+            || [ \( $? -gt 1 \) -a \( $? -lt 127 \) ]
 
   node:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - npm-audit
-          - osv-scanner
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -44,61 +49,30 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "lts/*"
-      - name: Set up Go
-        if: ${{ matrix.target == 'osv-scanner' }}
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version: stable
+      - name: Create BOM
+        working-directory: node
+        run: |
+          npm install --omit=dev --package-lock-only --no-audit
+          npm sbom --omit=dev --package-lock-only --sbom-format cyclonedx > bom.cdx.json
       - name: Scan
-        run: make scan-node-${{ matrix.target }}
+        run: |
+          docker run --rm \
+            --volume './node/bom.cdx.json:/bom.cdx.json' \
+            ghcr.io/google/osv-scanner \
+            --sbom bom.cdx.json \
+            --format markdown >> ${GITHUB_STEP_SUMMARY}
 
-  java_osv_scanner:
-    name: "java (osv-scanner)"
+  java:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.ref }}
-      - name: Set up Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version: stable
       - name: Scan
-        run: make scan-java-osv-scanner
-
-  java_dependency_check:
-    name: "java (dependency-check)"
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: java
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ inputs.ref }}
-      - name: Set up Java
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
-        with:
-          java-version: 21
-          distribution: temurin
-          cache: maven
-      - name: Download dependencies
-        run: mvn dependency:copy-dependencies -DincludeScope=runtime
-      - name: Scan
-        env:
-          JAVA_HOME: /opt/jdk
-        uses: dependency-check/Dependency-Check_Action@2ba636726705b0f74f126ebeaacaf2ad4600b967 # main
-        with:
-          project: fabric-gateway
-          path: java/target/dependency
-          format: HTML
-          out: reports
-          args: >
-            --suppression java/dependency-suppression.xml
-            --failOnCVSS 4
-      - name: Archive dependency-check report
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: dependency-check-report-${{ inputs.ref || github.event.pull_request.number || github.ref_name }}
-          path: reports
+        run: |
+          docker run --rm \
+            --volume './java/pom.xml:/pom.xml' \
+            ghcr.io/google/osv-scanner \
+            --lockfile pom.xml \
+            --data-source native \
+            --format markdown >> ${GITHUB_STEP_SUMMARY}

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,6 @@ export SOFTHSM2_CONF ?= $(base_dir)/softhsm2.conf
 TMPDIR ?= /tmp
 TMPDIR := $(abspath $(TMPDIR))
 
-osv_scanner := go run github.com/google/osv-scanner/v2/cmd/osv-scanner@latest
-govulncheck := go run golang.org/x/vuln/cmd/govulncheck@latest
-nancy := go run github.com/sonatype-nexus-community/nancy@latest
-
 maven := mvn
 ifneq (, $(shell command -v mvnd 2>/dev/null))
 	maven := mvnd
@@ -110,23 +106,29 @@ golangci-lint: $(go_bin_dir)/golangci-lint
 scan: scan-go scan-node scan-java
 
 .PHONY: scan-go
-scan-go: scan-go-govulncheck scan-go-nancy scan-go-osv-scanner
+scan-go: scan-go-osv-scanner
 
 .PHONY: scan-go-govulncheck
 scan-go-govulncheck:
-	$(govulncheck) -tags pkcs11 -show verbose '$(go_dir)/...'
+	go install golang.org/x/vuln/cmd/govulncheck@latest
+	govulncheck -tags pkcs11 -show verbose '$(go_dir)/...'
 
 .PHONY: scan-go-nancy
 scan-go-nancy:
-	go list -json -deps '$(go_dir)/...' | $(nancy) sleuth
+	go install github.com/sonatype-nexus-community/nancy@latest
+	go list -json -deps '$(go_dir)/...' | nancy sleuth
+
+.PHONY: install-osv-scanner
+install-osv-scanner:
+	go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest
 
 .PHONY: scan-go-osv-scanner
-scan-go-osv-scanner:
+scan-go-osv-scanner: install-osv-scanner
 	echo "GoVersionOverride = '$$(go env GOVERSION | sed -e 's/^go//' -e 's/-.*$$//')'" > '$(TMPDIR)/osv-scanner.toml'
-	$(osv_scanner) scan --config='$(TMPDIR)/osv-scanner.toml' --lockfile='$(base_dir)/go.mod' || [ \( $$? -gt 1 \) -a \( $$? -lt 127 \) ]
+	osv-scanner scan --config='$(TMPDIR)/osv-scanner.toml' --lockfile='$(base_dir)/go.mod' || [ \( $$? -gt 1 \) -a \( $$? -lt 127 \) ]
 
 .PHONY: scan-node
-scan-node: scan-node-npm-audit scan-node-osv-scanner
+scan-node: scan-node-osv-scanner
 
 .PHONY: scan-node-npm-audit
 scan-node-npm-audit:
@@ -135,14 +137,14 @@ scan-node-npm-audit:
 		npm audit --omit=dev
 
 .PHONY: scan-node-osv-scanner
-scan-node-osv-scanner:
+scan-node-osv-scanner: install-osv-scanner
 	cd '$(node_dir)' && \
 		npm install --omit=dev --package-lock-only --no-audit && \
 		npm sbom --omit=dev --package-lock-only --sbom-format cyclonedx > bom.cdx.json && \
-		$(osv_scanner) scan --sbom=bom.cdx.json
+		osv-scanner scan --sbom=bom.cdx.json
 
 .PHONY: scan-java
-scan-java: scan-java-dependency-check scan-java-osv-scanner
+scan-java: scan-java-osv-scanner
 
 .PHONY: scan-java-dependency-check
 scan-java-dependency-check:
@@ -150,8 +152,8 @@ scan-java-dependency-check:
 		$(maven) dependency-check:check -P owasp
 
 .PHONY: scan-java-osv-scanner
-scan-java-osv-scanner:
-	$(osv_scanner) scan --lockfile='$(java_dir)/pom.xml' --data-source=native
+scan-java-osv-scanner: install-osv-scanner
+	osv-scanner scan --lockfile='$(java_dir)/pom.xml' --data-source=native
 
 .PHONY: install-mockery
 install-mockery:


### PR DESCRIPTION
Use only OSV-Scanner for vulnerability scanning since other tools have been shown not to provide additional coverage. Other tools are still available to run manually using Makefile targets.

In GitHub Actions workflows, the OSV-Scanner Docker image is used since this is cached and provides better performance by avoiding installation overheads. The exception is Go, where the Go runtime is already installed and some additional exit code handling is required to avoid failure on uncalled vulnerabilities.